### PR TITLE
Tweaks movement speed.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -37,8 +37,8 @@ OOC_DURING_ROUND
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-RUN_DELAY 2
-WALK_DELAY 4
+RUN_DELAY 1.50
+WALK_DELAY 3
 
 ## The variables below affect the movement of specific mob types.
 HUMAN_DELAY 0


### PR DESCRIPTION
Slightly increases movement speed.
This errs more towards the speed of /tg/ and less towards BayStation.

Old speed made local testing server feel like it was clunky and/or lagging. This fixes that.

:cl: MrRory
tweak: All NT Personnel must now complete a mandatory cardiovascular fitness exam.
/:cl:
