### PR TITLE
Podpeople as roundstart ft stat changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -8,10 +8,12 @@
 	attack_sound = 'sound/weapons/slice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	burnmod = 1.25
-	heatmod = 1.5
+	heatmod = 1.45
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN
+	toxic_food = MEAT | DAIRY
+	roundstart = TRUE
 
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -34,18 +36,20 @@
 		if(H.nutrition > NUTRITION_LEVEL_FULL)
 			H.nutrition = NUTRITION_LEVEL_FULL
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(1,1)
-			H.adjustToxLoss(-1)
-			H.adjustOxyLoss(-1)
+			H.heal_overall_damage(1,0.65)
+			H.adjustOxyLoss(-0.5)
 
-	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
-		H.take_overall_damage(2,0)
+	if(H.nutrition < NUTRITION_LEVEL_STARVING + 55)
+		H.adjustOxyLoss(5) //can eat to negate this unfortunately
+		H.adjustToxLoss(3)
+
 
 /datum/species/pod/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.id == "plantbgone")
-		H.adjustToxLoss(3)
+		H.adjustToxLoss(5)
 		H.reagents.remove_reagent(chem.id, REAGENTS_METABOLISM)
-		return 1
+		H.confused = max(H.confused, 1)
+		return TRUE
 
 /datum/species/pod/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
 	switch(P.type)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -13,7 +13,6 @@
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	toxic_food = MEAT | DAIRY
-	roundstart = TRUE
 
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()


### PR DESCRIPTION
🆑 DanielMclovin
tweak: Podpeople take more damage from plant b gone, heal less fire damage and brute, become roundstart, and last but not least take tox/oxy damage instead of all types of damage from being in the dark for too long.
/🆑

Essentially this adds a new face to the station as well as thing to fight for antags/players on the regular.